### PR TITLE
Add GitHub Action workflow for building the project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Test"
+name: "Build"
 on:
   pull_request:
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
 jobs:
-  tests:
+  build-target:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: "Test"
+on:
+  pull_request:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v25
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v14
+      with:
+        name: henryouly
+        # If you chose API tokens for write access OR if you have a private cache
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: ./misc/utils.sh build-target-nix x86_64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: cachix/cachix-action@v14
       with:
         name: henryouly
+        # If you chose signing key for write access
+        signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
         # If you chose API tokens for write access OR if you have a private cache
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: ./misc/utils.sh build-target-nix x86_64


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building the project. The workflow is triggered on both pull requests and pushes, and it sets up the environment using Nix and Cachix before running the build script.

Continuous integration setup:

* Added `.github/workflows/build.yml` to define a "Build" workflow that runs on pull requests and pushes, checks out the code, installs Nix, configures Cachix for caching, and executes the build script (`./misc/utils.sh build-target-nix x86_64`).
