### PR TITLE
Add building docker image workflow

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-app:
-    uses: ./.github/workflows/build.yml@dev
+    uses: ./.github/workflows/build.yml
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -15,6 +15,12 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-artifacts
+        path: build/x86_64
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-app:
-    uses: ./.github/workflows/build.yml@${{ github.ref }}
+    uses: ./.github/workflows/build.yml@${{ github.ref_name }}
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "master" ]
 
 jobs:
   build-app:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -5,8 +5,12 @@ on:
     branches: [ "main", "dev" ]
 
 jobs:
+  build-app:
+    uses: ./.github/workflows/build.yml@${{ github.ref }}
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: build-app
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
@@ -27,9 +31,6 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-buildx-
-
-    - name: Build application
-      uses: ./.github/workflows/build.yml
 
     - name: Download libusb dependency
       run: |

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,44 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Cache Docker layers
+      uses: actions/cache@v3
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Build application
+      uses: ./.github/workflows/build.yml
+
+    - name: Download libusb dependency
+      run: |
+        ./misc/utils.sh download-debian-libusb
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./misc/Dockerfile
+        push: true
+        tags: henryouly/sentryshot:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-app:
-    uses: ./.github/workflows/build.yml@${{ github.ref_name }}
+    uses: ./.github/workflows/build.yml@dev
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,8 @@ jobs:
         # If you chose API tokens for write access OR if you have a private cache
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: ./misc/utils.sh build-target-nix x86_64
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: build-artifacts
+        path: build/x86_64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: "Build"
 on:
   pull_request:
   push:
+  workflow_call:
+
 jobs:
   build-target:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request introduces a new workflow for building and publishing Docker images, and enhances the existing build workflow to support artifact sharing between jobs. The changes improve CI automation by enabling multi-step builds and seamless Docker image deployment.

**Docker image build and deployment automation:**

* Added a new workflow file `.github/workflows/build-docker-image.yml` to automate building and pushing Docker images to Docker Hub, including steps for artifact download, Docker setup, dependency management, and caching.

**Build workflow enhancements:**

* Enabled the `build.yml` workflow to be triggered by other workflows using `workflow_call`, allowing better workflow composition and reuse.
* Added a step to upload build artifacts (`build/x86_64`) in the `build.yml` workflow so that downstream jobs (like Docker image builds) can access compiled outputs.