### PR TITLE
Add steps to preserve file attributes such as executable permissions

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -19,7 +19,10 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: build-artifacts
-        path: build/x86_64
+        path: .
+    
+    - name: Extract archived files
+      run: tar -xvf sentryshot-x86_64.tar
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,10 @@ jobs:
         # If you chose API tokens for write access OR if you have a private cache
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: ./misc/utils.sh build-target-nix x86_64
+    - name: Tar files
+      run: tar -cvf sentryshot-x86_64.tar build/x86_64
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: build-artifacts
-        path: build/x86_64
+        path: sentryshot-x86_64.tar


### PR DESCRIPTION
This pull request updates the build and artifact handling steps in the GitHub workflow files to improve the way build artifacts are packaged and extracted. Instead of uploading the entire `build/x86_64` directory, the workflow now creates a tarball (`sentryshot-x86_64.tar`) of the build output, uploads it as a single artifact, and then extracts it in downstream jobs. This streamlines artifact management and ensures consistency across jobs.

**Build artifact packaging and extraction:**

* In `.github/workflows/build.yml`, after building the target, the workflow now tars the `build/x86_64` directory into `sentryshot-x86_64.tar` and uploads this tarball as the build artifact instead of the raw directory.
* In `.github/workflows/build-docker-image.yml`, the workflow downloads the tarball artifact to the workspace and adds a step to extract its contents before proceeding with the Docker build.…when building docker image.