### PR TITLE
feat: use half crate for f32 to f16 conversion.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1677,6 +1677,7 @@ dependencies = [
  "async-trait",
  "common",
  "glob",
+ "half",
  "http",
  "plugin",
  "prost 0.14.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ bytesize = "2"
 console-subscriber = "0.4"
 criterion = { version = "0.5.0", features = ["async_tokio"] }
 futures-lite = "2"
+half = "2.6.0"
 headers = "0.4.0"
 http = "1.0.0"
 httpdate = "1.0.2"

--- a/plugins/openvino/Cargo.toml
+++ b/plugins/openvino/Cargo.toml
@@ -24,6 +24,7 @@ sentryshot_scale.workspace = true
 sentryshot_util.workspace = true
 
 async-trait.workspace = true
+half.workspace = true
 http.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -36,6 +37,7 @@ tonic.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 tonic-prost.workspace = true
+
 
 [build-dependencies]
 tonic-prost-build.workspace = true


### PR DESCRIPTION
This pull request updates the OpenVINO plugin to use the `half` crate for half-precision float conversions, replacing custom float conversion functions with a standardized and more reliable approach. The changes simplify the codebase and improve maintainability by leveraging an external library.

**Dependency updates:**

* Added the `half` crate to the root `Cargo.toml` and enabled it as a workspace dependency in `plugins/openvino/Cargo.toml`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R48) [[2]](diffhunk://#diff-e4ee98279a465f1e13b3628fe4190fbae65e1af67248d583cb5535f935d48677R27)

**Code simplification and refactoring:**

* Replaced custom float conversion functions (`float32_to_f16`, `half_to_float32`) in `plugins/openvino/detector.rs` with the `half::f16` type and its methods for converting between `f32` and half-precision floats. [[1]](diffhunk://#diff-d94bdbbc0e755b51abe33e0e99781321f872204c71631aab7ec2d26d19268c79L225-L285) [[2]](diffhunk://#diff-d94bdbbc0e755b51abe33e0e99781321f872204c71631aab7ec2d26d19268c79L297-R253)
* Removed the manual implementations of float conversion functions, reducing code complexity and potential for errors.

**Imports:**

* Added `use half::f16;` to `plugins/openvino/detector.rs` to enable usage of the half-precision float type and conversion methods.