### PR TITLE
Only push on master branch triggers build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: "Build"
 on:
   pull_request:
   push:
-    branches: [ "master" ]  
+    branches: [ "master" ]
   workflow_call:
 
 jobs:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change ensures that the build workflow will only run automatically when code is pushed to the `master` branch.