### PR TITLE
Status plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,14 +2603,15 @@ name = "status"
 version = "0.3.4"
 dependencies = [
  "async-trait",
+ "axum 0.8.1",
  "common",
  "plugin",
  "pretty_assertions",
  "serde",
+ "serde_json",
  "thiserror 2.0.11",
  "tokio",
  "tokio-util",
- "upon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "plugin",
  "pretty_assertions",
  "serde",
+ "tokio",
  "upon",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "status"
+version = "0.3.4"
+dependencies = [
+ "async-trait",
+ "common",
+ "plugin",
+ "pretty_assertions",
+ "serde",
+]
+
+[[package]]
 name = "streamer"
 version = "0.3.4"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "bitstream-io"
@@ -1330,9 +1330,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1596,12 +1596,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2609,6 +2637,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "sysinfo",
  "thiserror 2.0.11",
  "tokio",
  "tokio-util",
@@ -2669,6 +2698,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
 
 [[package]]
 name = "tempfile"
@@ -3385,6 +3428,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3416,6 +3561,15 @@ dependencies = [
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,7 +2607,9 @@ dependencies = [
  "plugin",
  "pretty_assertions",
  "serde",
+ "thiserror 2.0.11",
  "tokio",
+ "tokio-util",
  "upon",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2607,6 +2607,7 @@ dependencies = [
  "plugin",
  "pretty_assertions",
  "serde",
+ "upon",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "plugins/object_detection",
   "plugins/object_detection_tflite",
   "plugins/openvino",
+  "plugins/status",
   "plugins/thumb_scale",
 
   "src/sentryshot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ rand_chacha = "0.9"
 sha2 = "0.10.8"
 serde = { version = "1.0.152", default-features = false, features = ["alloc"] }
 serde_json = "1.0.92"
+sysinfo = "0.36.1"
 tempfile = "3.16"
 test-case = "3"
 thiserror = "2"

--- a/misc/utils.sh
+++ b/misc/utils.sh
@@ -46,7 +46,7 @@ if [ -z "${CARGO_TARGET_DIR}" ]; then
 	export CARGO_TARGET_DIR="$target_dir"
 fi
 
-plugins="auth_basic auth_none motion mqtt object_detection object_detection_tflite openvino thumb_scale"
+plugins="auth_basic auth_none motion mqtt object_detection object_detection_tflite openvino status thumb_scale"
 packages="-p sentryshot"
 for plugin in $plugins; do
 	packages="$packages -p $plugin"

--- a/plugins/status/Cargo.toml
+++ b/plugins/status/Cargo.toml
@@ -20,7 +20,9 @@ plugin.path = "../../src/plugin"
 
 async-trait.workspace = true
 serde.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 upon.workspace = true
 
 [dev-dependencies]

--- a/plugins/status/Cargo.toml
+++ b/plugins/status/Cargo.toml
@@ -20,6 +20,7 @@ plugin.path = "../../src/plugin"
 
 async-trait.workspace = true
 serde.workspace = true
+upon.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/plugins/status/Cargo.toml
+++ b/plugins/status/Cargo.toml
@@ -20,6 +20,7 @@ plugin.path = "../../src/plugin"
 
 async-trait.workspace = true
 serde.workspace = true
+tokio.workspace = true
 upon.workspace = true
 
 [dev-dependencies]

--- a/plugins/status/Cargo.toml
+++ b/plugins/status/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "status"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[lib]
+name = "status"
+path = "status.rs"
+crate-type = ["cdylib"]
+doctest = false
+
+[dependencies]
+common.path = "../../src/common"
+plugin.path = "../../src/plugin"
+
+async-trait.workspace = true
+serde.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/plugins/status/Cargo.toml
+++ b/plugins/status/Cargo.toml
@@ -18,12 +18,13 @@ doctest = false
 common.path = "../../src/common"
 plugin.path = "../../src/plugin"
 
+axum.workspace = true
 async-trait.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-upon.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/plugins/status/Cargo.toml
+++ b/plugins/status/Cargo.toml
@@ -22,6 +22,7 @@ axum.workspace = true
 async-trait.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sysinfo.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/plugins/status/status.rs
+++ b/plugins/status/status.rs
@@ -37,123 +37,41 @@ pub extern "Rust" fn load(_app: &dyn plugin::Application) -> Arc<dyn Plugin> {
 
 struct StatusPlugin;
 
+struct Status {
+  cpu_usage: u8,
+  ram_usage: u8,
+  disk_usage: u8,
+  disk_usage_formatted: String,
+}
+
 #[async_trait]
 impl Plugin for StatusPlugin {
     fn edit_templates(&self, templates: &mut Templates) {
         // Append "Hello world" to sidebar (similar pattern to auth_basic)
         if let Some(sidebar) = templates.get_mut("sidebar") {
             let target = "<!-- NAVBAR_BOTTOM -->";
-            let addition = r#"<style>
-		#logout {
-			margin-bottom: 0;
-		}
+            let addition = include_str!("templates/status.tpl");
 
-		.statusbar {
-			width: var(--sidebar-width);
-			margin-bottom: 0.4rem;
-		}
-		.statusbar li {
-			margin-top: 0.2rem;
-		}
+            // Mock status data.
+            let status = Status {
+              cpu_usage: 42,
+              ram_usage: 33,
+              disk_usage: 73,
+              disk_usage_formatted: "120G / 160G".to_string(),
+            };
 
-		.statusbar-text-container {
-			display: flex;
-		}
-		.statusbar-text {
-			padding-right: 0.4rem;
-			padding-left: 0.4rem;
-			color: var(--color-text);
-			font-size: 0.4em;
-		}
-		.statusbar-number {
-			margin-left: auto;
-		}
-		.statusbar-progressbar {
-			height: 0.3rem;
-			margin-right: 0.3rem;
-			margin-left: 0.3rem;
-			padding: 0.05rem;
-			background: var(--color0);
-			border-radius: 0.2rem;
-		}
-		.statusbar-progressbar span {
-			display: block;
-			width: 50%;
-			height: 100%;
-			background: var(--color1);
-			border-top-left-radius: 0.5rem;
-			border-top-right-radius: 0.2rem;
-			border-bottom-right-radius: 0.2rem;
-			border-bottom-left-radius: 0.5rem;
-		}
-	</style>
-	<ul class="statusbar">
-		<li>
-			<div class="statusbar-text-container">
-				<span class="statusbar-text">CPU</span>
-				<span class="statusbar-text statusbar-number"
-					>{{ .status.CPUUsage }}%</span
-				>
-			</div>
-			<div class="statusbar-progressbar">
-				<span style="width: {{ .status.CPUUsage }}%"></span>
-			</div>
-		</li>
-		<li>
-			<div class="statusbar-text-container">
-				<span class="statusbar-text">RAM</span>
-				<span class="statusbar-text statusbar-number"
-					>{{ .status.RAMUsage }}%</span
-				>
-			</div>
-			<div class="statusbar-progressbar">
-				<span style="width: {{ .status.RAMUsage }}%"></span>
-			</div>
-		</li>
-		<li>
-			<div class="statusbar-text-container">
-				<span class="statusbar-text">DISK</span>
-				<span
-					style="margin: auto; font-size: 0.35rem"
-					class="statusbar-text"
-					>{{ .status.DiskUsageFormatted }}</span
-				>
-				<span class="statusbar-text statusbar-number"
-					>{{ .status.DiskUsage }}%</span
-				>
-			</div>
-			<div class="statusbar-progressbar">
-				<span style="width: {{ .status.DiskUsage }}%"></span>
-			</div>
-		</li>
-	</ul>"#;
-			// Mock status data struct.
-			struct Status {
-				cpu_usage: u8,
-				ram_usage: u8,
-				disk_usage: u8,
-				disk_usage_formatted: String,
-			}
+            // Replace template tokens with mock values so the upon template
+            // engine sees concrete values when rendering.
+            let mut filled = addition.to_string();
+            filled = filled.replace("{{ .status.CPUUsage }}", &format!("{}", status.cpu_usage));
+            filled = filled.replace("{{ .status.RAMUsage }}", &format!("{}", status.ram_usage));
+            filled = filled.replace("{{ .status.DiskUsage }}", &format!("{}", status.disk_usage));
+            filled = filled.replace(
+              "{{ .status.DiskUsageFormatted }}",
+              &status.disk_usage_formatted,
+            );
 
-			let status = Status {
-				cpu_usage: 42,
-				ram_usage: 33,
-				disk_usage: 73,
-				disk_usage_formatted: "120G / 160G".to_string(),
-			};
-
-			// Replace template tokens with mock values so the upon template
-			// engine sees concrete values when rendering.
-			let mut filled = addition.to_string();
-			filled = filled.replace("{{ .status.CPUUsage }}", &format!("{}", status.cpu_usage));
-			filled = filled.replace("{{ .status.RAMUsage }}", &format!("{}", status.ram_usage));
-			filled = filled.replace("{{ .status.DiskUsage }}", &format!("{}", status.disk_usage));
-			filled = filled.replace(
-				"{{ .status.DiskUsageFormatted }}",
-				&status.disk_usage_formatted,
-			);
-
-			*sidebar = sidebar.replace(target, &(filled + target));
+            *sidebar = sidebar.replace(target, &(filled + target));
         }
     }
 

--- a/plugins/status/status.rs
+++ b/plugins/status/status.rs
@@ -66,10 +66,10 @@ enum RunError {
 impl StatusPlugin {
     fn new(rt_handle: Handle, logger: ArcLogger) -> Self {
         let status = Arc::new(Mutex::new(Status {
-            cpu_usage: 42,
-            ram_usage: 37,
-            disk_usage: 67,
-            disk_usage_formatted: "120G / 160G".to_string(),
+            cpu_usage: 0,
+            ram_usage: 0,
+            disk_usage: 0,
+            disk_usage_formatted: "Loading...".to_string(),
         }));
 
         let sys = System::new_all();

--- a/plugins/status/status.rs
+++ b/plugins/status/status.rs
@@ -73,7 +73,7 @@ impl Plugin for StatusPlugin {
 			margin-right: 0.3rem;
 			margin-left: 0.3rem;
 			padding: 0.05rem;
-			background: var(--colorbg);
+			background: var(--color0);
 			border-radius: 0.2rem;
 		}
 		.statusbar-progressbar span {

--- a/plugins/status/status.rs
+++ b/plugins/status/status.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+use async_trait::async_trait;
+use common::{
+    LogSource
+};
+use plugin::{Plugin, PreLoadPlugin, types::{Router, Templates}};
+use std::ffi::c_char;
+use std::sync::Arc;
+
+#[unsafe(no_mangle)]
+pub extern "C" fn version() -> *const c_char {
+    plugin::get_version()
+}
+
+#[unsafe(no_mangle)]
+pub extern "Rust" fn pre_load() -> Box<dyn PreLoadPlugin> {
+    Box::new(PreLoadStatus)
+}
+
+struct PreLoadStatus;
+
+impl PreLoadPlugin for PreLoadStatus {
+    fn add_log_source(&self) -> Option<LogSource> {
+        None
+    }
+
+    fn set_new_auth(&self) -> Option<plugin::types::NewAuthFn> {
+        None
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "Rust" fn load(_app: &dyn plugin::Application) -> Arc<dyn Plugin> {
+    Arc::new(StatusPlugin {})
+}
+
+struct StatusPlugin;
+
+#[async_trait]
+impl Plugin for StatusPlugin {
+    fn edit_templates(&self, templates: &mut Templates) {
+        // Append "Hello world" to sidebar (similar pattern to auth_basic)
+        if let Some(sidebar) = templates.get_mut("sidebar") {
+            let target = "<!-- NAVBAR_BOTTOM -->";
+            let addition = "<div class=\"p-2\">Hello world</div>";
+            *sidebar = sidebar.replace(target, &(addition.to_owned() + target));
+        }
+    }
+
+    fn route(&self, router: Router) -> Router {
+        router
+    }
+}

--- a/plugins/status/status.rs
+++ b/plugins/status/status.rs
@@ -43,8 +43,117 @@ impl Plugin for StatusPlugin {
         // Append "Hello world" to sidebar (similar pattern to auth_basic)
         if let Some(sidebar) = templates.get_mut("sidebar") {
             let target = "<!-- NAVBAR_BOTTOM -->";
-            let addition = "<div class=\"p-2\">Hello world</div>";
-            *sidebar = sidebar.replace(target, &(addition.to_owned() + target));
+            let addition = r#"<style>
+		#logout {
+			margin-bottom: 0;
+		}
+
+		.statusbar {
+			width: var(--sidebar-width);
+			margin-bottom: 0.4rem;
+		}
+		.statusbar li {
+			margin-top: 0.2rem;
+		}
+
+		.statusbar-text-container {
+			display: flex;
+		}
+		.statusbar-text {
+			padding-right: 0.4rem;
+			padding-left: 0.4rem;
+			color: var(--color-text);
+			font-size: 0.4em;
+		}
+		.statusbar-number {
+			margin-left: auto;
+		}
+		.statusbar-progressbar {
+			height: 0.3rem;
+			margin-right: 0.3rem;
+			margin-left: 0.3rem;
+			padding: 0.05rem;
+			background: var(--colorbg);
+			border-radius: 0.2rem;
+		}
+		.statusbar-progressbar span {
+			display: block;
+			width: 50%;
+			height: 100%;
+			background: var(--color1);
+			border-top-left-radius: 0.5rem;
+			border-top-right-radius: 0.2rem;
+			border-bottom-right-radius: 0.2rem;
+			border-bottom-left-radius: 0.5rem;
+		}
+	</style>
+	<ul class="statusbar">
+		<li>
+			<div class="statusbar-text-container">
+				<span class="statusbar-text">CPU</span>
+				<span class="statusbar-text statusbar-number"
+					>{{ .status.CPUUsage }}%</span
+				>
+			</div>
+			<div class="statusbar-progressbar">
+				<span style="width: {{ .status.CPUUsage }}%"></span>
+			</div>
+		</li>
+		<li>
+			<div class="statusbar-text-container">
+				<span class="statusbar-text">RAM</span>
+				<span class="statusbar-text statusbar-number"
+					>{{ .status.RAMUsage }}%</span
+				>
+			</div>
+			<div class="statusbar-progressbar">
+				<span style="width: {{ .status.RAMUsage }}%"></span>
+			</div>
+		</li>
+		<li>
+			<div class="statusbar-text-container">
+				<span class="statusbar-text">DISK</span>
+				<span
+					style="margin: auto; font-size: 0.35rem"
+					class="statusbar-text"
+					>{{ .status.DiskUsageFormatted }}</span
+				>
+				<span class="statusbar-text statusbar-number"
+					>{{ .status.DiskUsage }}%</span
+				>
+			</div>
+			<div class="statusbar-progressbar">
+				<span style="width: {{ .status.DiskUsage }}%"></span>
+			</div>
+		</li>
+	</ul>"#;
+			// Mock status data struct.
+			struct Status {
+				cpu_usage: u8,
+				ram_usage: u8,
+				disk_usage: u8,
+				disk_usage_formatted: String,
+			}
+
+			let status = Status {
+				cpu_usage: 42,
+				ram_usage: 33,
+				disk_usage: 73,
+				disk_usage_formatted: "120G / 160G".to_string(),
+			};
+
+			// Replace template tokens with mock values so the upon template
+			// engine sees concrete values when rendering.
+			let mut filled = addition.to_string();
+			filled = filled.replace("{{ .status.CPUUsage }}", &format!("{}", status.cpu_usage));
+			filled = filled.replace("{{ .status.RAMUsage }}", &format!("{}", status.ram_usage));
+			filled = filled.replace("{{ .status.DiskUsage }}", &format!("{}", status.disk_usage));
+			filled = filled.replace(
+				"{{ .status.DiskUsageFormatted }}",
+				&status.disk_usage_formatted,
+			);
+
+			*sidebar = sidebar.replace(target, &(filled + target));
         }
     }
 

--- a/plugins/status/status.rs
+++ b/plugins/status/status.rs
@@ -119,15 +119,7 @@ impl StatusPlugin {
                 sys.refresh_cpu_usage();
                 sys.refresh_memory();
 
-                let cpu_usage = {
-                    let cpus = sys.cpus();
-                    if cpus.is_empty() {
-                        0u8
-                    } else {
-                        let sum: f64 = cpus.iter().map(|c| c.cpu_usage() as f64).sum();
-                        (sum / (cpus.len() as f64)).round() as u8
-                    }
-                };
+                let cpu_usage = sys.global_cpu_usage() as u8;
 
                 let total_mem = sys.total_memory(); // KB
                 let used_mem = sys.used_memory(); // KB
@@ -136,6 +128,8 @@ impl StatusPlugin {
                 } else {
                     0
                 };
+
+                self.logger.log(LogEntry::new2(LogLevel::Debug, "status", format!("CPU {}%, RAM {}%", cpu_usage, ram_usage).as_str()));
 
                 (cpu_usage, ram_usage)
             };
@@ -170,7 +164,7 @@ impl StatusPlugin {
 
             let sleep = || {
                 let _enter = self.rt_handle.enter();
-                tokio::time::sleep(Duration::from_secs(10))
+                tokio::time::sleep(Duration::from_secs(30))
             };
             tokio::select! {
                 () = token.cancelled() => return Ok(()),

--- a/plugins/status/status.rs
+++ b/plugins/status/status.rs
@@ -125,7 +125,7 @@ impl StatusPlugin {
                     Ok(guard) => guard,
                     Err(poisoned) => {
                         self.logger.log(LogEntry::new2(
-                            LogLevel::Warn,
+                            LogLevel::Warning,
                             "status",
                             "Mutex poisoned while locking system; using inner value.",
                         ));

--- a/plugins/status/templates/status.tpl
+++ b/plugins/status/templates/status.tpl
@@ -46,23 +46,23 @@
   <li>
     <div class="statusbar-text-container">
       <span class="statusbar-text">CPU</span>
-      <span class="statusbar-text statusbar-number"
-        >{{ status.CPUUsage }}%</span
-      >
+        <span id="status-cpu-number" class="statusbar-text statusbar-number"
+          >0%</span
+        >
     </div>
     <div class="statusbar-progressbar">
-      <span style="width: {{ status.CPUUsage }}%"></span>
+        <span id="status-cpu-bar" style="width: 0%"></span>
     </div>
   </li>
   <li>
     <div class="statusbar-text-container">
       <span class="statusbar-text">RAM</span>
-      <span class="statusbar-text statusbar-number"
-        >{{ status.RAMUsage }}%</span
-      >
+        <span id="status-ram-number" class="statusbar-text statusbar-number"
+          >0%</span
+        >
     </div>
     <div class="statusbar-progressbar">
-      <span style="width: {{ status.RAMUsage }}%"></span>
+        <span id="status-ram-bar" style="width: 0%"></span>
     </div>
   </li>
   <li>
@@ -71,14 +71,43 @@
       <span
         style="margin: auto; font-size: 0.35rem"
         class="statusbar-text"
-        >{{ status.DiskUsageFormatted }}</span
+        >120G / 160G</span
       >
-      <span class="statusbar-text statusbar-number"
-        >{{ status.DiskUsage }}%</span
-      >
+        <span id="status-disk-number" class="statusbar-text statusbar-number"
+          >0%</span
+        >
     </div>
     <div class="statusbar-progressbar">
-      <span style="width: {{ status.DiskUsage }}%"></span>
+        <span id="status-disk-bar" style="width: 0%"></span>
     </div>
   </li>
 </ul>
+  <script>
+  // Poll /api/status and update the sidebar status bar values.
+  async function updateStatus() {
+    try {
+      const res = await fetch('/api/status');
+      if (!res.ok) return;
+      const s = await res.json();
+      const setText = (id, v) => { const el = document.getElementById(id); if (el) el.textContent = v; };
+      const setWidth = (id, v) => { const el = document.getElementById(id); if (el) el.style && (el.style.width = v + '%'); };
+
+      setText('status-cpu-number', s.cpu_usage + '%');
+      setWidth('status-cpu-bar', s.cpu_usage);
+
+      setText('status-ram-number', s.ram_usage + '%');
+      setWidth('status-ram-bar', s.ram_usage);
+
+      setText('status-disk-number', s.disk_usage + '%');
+      setText('status-disk-formatted', s.disk_usage_formatted);
+      setWidth('status-disk-bar', s.disk_usage);
+    } catch (e) {
+      console.debug('status update failed', e);
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    updateStatus();
+    setInterval(updateStatus, 5000);
+  });
+  </script>

--- a/plugins/status/templates/status.tpl
+++ b/plugins/status/templates/status.tpl
@@ -69,10 +69,10 @@
     <div class="statusbar-text-container">
       <span class="statusbar-text">DISK</span>
       <span
+        id="status-disk-formatted"
         style="margin: auto; font-size: 0.35rem"
         class="statusbar-text"
-        >120G / 160G</span
-      >
+        >120G / 160G</span>
         <span id="status-disk-number" class="statusbar-text statusbar-number"
           >0%</span
         >

--- a/plugins/status/templates/status.tpl
+++ b/plugins/status/templates/status.tpl
@@ -47,22 +47,22 @@
     <div class="statusbar-text-container">
       <span class="statusbar-text">CPU</span>
       <span class="statusbar-text statusbar-number"
-        >{{ .status.CPUUsage }}%</span
+        >{{ status.CPUUsage }}%</span
       >
     </div>
     <div class="statusbar-progressbar">
-      <span style="width: {{ .status.CPUUsage }}%"></span>
+      <span style="width: {{ status.CPUUsage }}%"></span>
     </div>
   </li>
   <li>
     <div class="statusbar-text-container">
       <span class="statusbar-text">RAM</span>
       <span class="statusbar-text statusbar-number"
-        >{{ .status.RAMUsage }}%</span
+        >{{ status.RAMUsage }}%</span
       >
     </div>
     <div class="statusbar-progressbar">
-      <span style="width: {{ .status.RAMUsage }}%"></span>
+      <span style="width: {{ status.RAMUsage }}%"></span>
     </div>
   </li>
   <li>
@@ -71,14 +71,14 @@
       <span
         style="margin: auto; font-size: 0.35rem"
         class="statusbar-text"
-        >{{ .status.DiskUsageFormatted }}</span
+        >{{ status.DiskUsageFormatted }}</span
       >
       <span class="statusbar-text statusbar-number"
-        >{{ .status.DiskUsage }}%</span
+        >{{ status.DiskUsage }}%</span
       >
     </div>
     <div class="statusbar-progressbar">
-      <span style="width: {{ .status.DiskUsage }}%"></span>
+      <span style="width: {{ status.DiskUsage }}%"></span>
     </div>
   </li>
 </ul>

--- a/plugins/status/templates/status.tpl
+++ b/plugins/status/templates/status.tpl
@@ -1,0 +1,84 @@
+<style>
+  #logout {
+    margin-bottom: 0;
+  }
+
+  .statusbar {
+    width: var(--sidebar-width);
+    margin-bottom: 0.4rem;
+  }
+  .statusbar li {
+    margin-top: 0.2rem;
+  }
+
+  .statusbar-text-container {
+    display: flex;
+  }
+  .statusbar-text {
+    padding-right: 0.4rem;
+    padding-left: 0.4rem;
+    color: var(--color-text);
+    font-size: 0.4em;
+  }
+  .statusbar-number {
+    margin-left: auto;
+  }
+  .statusbar-progressbar {
+    height: 0.3rem;
+    margin-right: 0.3rem;
+    margin-left: 0.3rem;
+    padding: 0.05rem;
+    background: var(--color0);
+    border-radius: 0.2rem;
+  }
+  .statusbar-progressbar span {
+    display: block;
+    width: 50%;
+    height: 100%;
+    background: var(--color1);
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.2rem;
+    border-bottom-right-radius: 0.2rem;
+    border-bottom-left-radius: 0.5rem;
+  }
+</style>
+<ul class="statusbar">
+  <li>
+    <div class="statusbar-text-container">
+      <span class="statusbar-text">CPU</span>
+      <span class="statusbar-text statusbar-number"
+        >{{ .status.CPUUsage }}%</span
+      >
+    </div>
+    <div class="statusbar-progressbar">
+      <span style="width: {{ .status.CPUUsage }}%"></span>
+    </div>
+  </li>
+  <li>
+    <div class="statusbar-text-container">
+      <span class="statusbar-text">RAM</span>
+      <span class="statusbar-text statusbar-number"
+        >{{ .status.RAMUsage }}%</span
+      >
+    </div>
+    <div class="statusbar-progressbar">
+      <span style="width: {{ .status.RAMUsage }}%"></span>
+    </div>
+  </li>
+  <li>
+    <div class="statusbar-text-container">
+      <span class="statusbar-text">DISK</span>
+      <span
+        style="margin: auto; font-size: 0.35rem"
+        class="statusbar-text"
+        >{{ .status.DiskUsageFormatted }}</span
+      >
+      <span class="statusbar-text statusbar-number"
+        >{{ .status.DiskUsage }}%</span
+      >
+    </div>
+    <div class="statusbar-progressbar">
+      <span style="width: {{ .status.DiskUsage }}%"></span>
+    </div>
+  </li>
+</ul>

--- a/plugins/status/templates/status.tpl
+++ b/plugins/status/templates/status.tpl
@@ -72,7 +72,7 @@
         id="status-disk-formatted"
         style="margin: auto; font-size: 0.35rem"
         class="statusbar-text"
-        >120G / 160G</span>
+        >Loading...</span>
         <span id="status-disk-number" class="statusbar-text statusbar-number"
           >0%</span
         >


### PR DESCRIPTION
This pull request adds a new `status` plugin to the project, which provides real-time system resource usage (CPU, RAM, and Disk) in the web interface sidebar. It includes backend logic for collecting system metrics, a REST API endpoint, and a frontend template for displaying live status updates. Supporting changes update build scripts and dependencies to include the new plugin and required system info library.

**Status plugin addition:**

* Introduced a new `status` plugin with its own crate definition (`plugins/status/Cargo.toml`). This plugin depends on `sysinfo` and other shared libraries for system metrics and integration.
* Implemented the main plugin logic in `plugins/status/status.rs`, which collects CPU, RAM, and Disk usage periodically, exposes an `/api/status` endpoint, and injects a status bar into the sidebar template.
* Added a sidebar template (`plugins/status/templates/status.tpl`) that displays live system metrics and polls the API every 5 seconds to update the UI.

**Build and dependency updates:**

* Registered the `status` plugin in the workspace members in `Cargo.toml` and added `sysinfo` as a dependency for system metrics. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R80)
* Updated the build utility script (`misc/utils.sh`) to include the `status` plugin in the build process.