### PR TITLE
feat: add grid size adjustment buttons to LiveView component

### DIFF
--- a/frontend/src/pages/LiveView.tsx
+++ b/frontend/src/pages/LiveView.tsx
@@ -39,11 +39,7 @@ export default function LiveView() {
             className="mr-2"
             variant={"secondary"}
             aria-label="Decrease grid size"
-            onClick={() => {
-              if (contentGridRef.current) {
-                setGridSize(Math.max(1, gridSize - 1));
-              }
-            }}
+            onClick={() => setGridSize(Math.max(1, gridSize - 1))}
             disabled={gridSize <= 1}
           >
             <Plus className="h-4 w-4" />
@@ -53,11 +49,7 @@ export default function LiveView() {
             className="mr-2"
             variant={"secondary"}
             aria-label="Increase grid size"
-            onClick={() => {
-              if (contentGridRef.current) {
-                setGridSize(Math.min(4, gridSize + 1));
-              }
-            }}
+            onClick={() => setGridSize(Math.min(4, gridSize + 1))}
             disabled={gridSize >= 4}
           >
             <Minus className="h-4 w-4" />

--- a/frontend/src/pages/LiveView.tsx
+++ b/frontend/src/pages/LiveView.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useRef } from "react";
+import { Minus, Plus } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 // @ts-ignore: This module is legacy and has no types
 import { newViewer } from "@/components/viewer/live";
 // @ts-ignore: This module is legacy and has no types
 import { setGlobals } from "@/components/viewer/libs/common";
+
+import { Button } from "@/components/ui/button";
 
 // Helper function to fetch environment data
 async function fetchEnvData(signal: AbortSignal) {
@@ -25,12 +28,48 @@ async function fetchEnvData(signal: AbortSignal) {
 export default function LiveView() {
   const contentGridRef = useRef<HTMLDivElement>(null);
 
-  const VideoGrid = ({ gridSize }: { gridSize: number }) => {
+  const VideoGrid = ({ initialGridSize }: { initialGridSize: number }) => {
+    const [gridSize, setGridSize] = useState(initialGridSize);
+
     return (
-      <div
-        ref={contentGridRef}
-        style={{ display: "grid", gridTemplateColumns: `repeat(${gridSize}, 1fr)` }}
-      />
+      <div>
+
+        <div className="mb-4 flex">
+          <Button
+            className="mr-2"
+            variant={"secondary"}
+            aria-label="Decrease grid size"
+            onClick={() => {
+              if (contentGridRef.current) {
+                setGridSize(Math.max(1, gridSize - 1));
+              }
+            }}
+            disabled={gridSize <= 1}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+
+          <Button
+            className="mr-2"
+            variant={"secondary"}
+            aria-label="Increase grid size"
+            onClick={() => {
+              if (contentGridRef.current) {
+                setGridSize(Math.min(4, gridSize + 1));
+              }
+            }}
+            disabled={gridSize >= 4}
+          >
+            <Minus className="h-4 w-4" />
+          </Button>
+        </div>
+
+        <div
+          ref={contentGridRef}
+          style={{ display: "grid", gridTemplateColumns: `repeat(${gridSize}, 1fr)` }}
+        />
+
+      </div>
     );
   };
 
@@ -77,8 +116,6 @@ export default function LiveView() {
   }, []);
 
   return (
-    <div>
-      <VideoGrid gridSize={3} />
-    </div>
+    <VideoGrid initialGridSize={3} />
   );
 }


### PR DESCRIPTION
This pull request updates the `LiveView` page to allow users to dynamically adjust the video grid size using UI buttons, improving usability and flexibility. The main changes include introducing state management for grid size and adding buttons to increase or decrease the grid.

**User interface enhancements:**

* Added `Plus` and `Minus` icon buttons from `lucide-react` and a `Button` component to the UI, allowing users to increase or decrease the grid size interactively. [[1]](diffhunk://#diff-b660feab9e7ac701315f51f4623009b31e1d9414fcadba27fa4dfbd67cd3dfdfL1-R9) [[2]](diffhunk://#diff-b660feab9e7ac701315f51f4623009b31e1d9414fcadba27fa4dfbd67cd3dfdfL28-R72)
* The grid size is now managed as a state variable (`useState`), enabling dynamic updates and limiting the grid size between 1 and 4.

**Component API update:**

* Changed the `VideoGrid` component prop from `gridSize` to `initialGridSize` to support the new stateful grid size. [[1]](diffhunk://#diff-b660feab9e7ac701315f51f4623009b31e1d9414fcadba27fa4dfbd67cd3dfdfL28-R72) [[2]](diffhunk://#diff-b660feab9e7ac701315f51f4623009b31e1d9414fcadba27fa4dfbd67cd3dfdfL80-R119)

**Code cleanup:**

* Removed the unnecessary wrapper `<div>` around the `VideoGrid` component in the main render function.