### PR TITLE
Implement new log viewer

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@ This is the frontend for SentryShot, a web application for viewing live video st
 - **Framework:** [Solid](https://solidjs.com/)
 - **Build Tool:** [Vite](https://vitejs.dev/)
 - **Language:** [TypeScript](https://www.typescriptlang.org/)
-- **UI Components:** [shadcn/ui](https://ui.shadcn.com/)
+- **UI Components:** [daisyUI](https://daisyui.com/)
 - **Styling:** [Tailwind CSS](https://tailwindcss.com/)
 - **Routing:** [React Router](https://reactrouter.com/)
 - **Tables:** [TanStack Table](https://tanstack.com/table)

--- a/frontend/src/components/logs-viewer/FilterPopover.tsx
+++ b/frontend/src/components/logs-viewer/FilterPopover.tsx
@@ -10,10 +10,11 @@ type Props = {
 };
 
 const ALL_LEVELS = ['error', 'warning', 'info', 'debug'];
+const DEFAULT_LEVELS = ['error', 'warning', 'info'];
 
 const FilterPopover: Component<Props> = (props) => {
   const [open, setOpen] = createSignal(false);
-  const [selLevels, setSelLevels] = createSignal<string[]>(props.levels ?? []);
+  const [selLevels, setSelLevels] = createSignal<string[]>(props.levels ?? DEFAULT_LEVELS);
   const [selMonitors, setSelMonitors] = createSignal<string[]>(props.monitors ?? []);
 
   function toggleLevel(l: string) {
@@ -30,7 +31,7 @@ const FilterPopover: Component<Props> = (props) => {
   }
 
   function reset() {
-    setSelLevels([]);
+    setSelLevels(DEFAULT_LEVELS);
     setSelMonitors([]);
   }
 
@@ -41,7 +42,7 @@ const FilterPopover: Component<Props> = (props) => {
       </button>
 
       {open() && (
-        <div class="absolute z-20 mt-2 p-4 bg-base-100 border rounded shadow w-72">
+        <div class="absolute right-0 z-20 mt-2 p-4 bg-base-100 border border-gray-300 rounded shadow w-72">
           <div class="mb-3">
             <div class="font-medium mb-2">Levels</div>
             <div class="flex gap-2 flex-wrap">
@@ -49,7 +50,7 @@ const FilterPopover: Component<Props> = (props) => {
                 <label class="inline-flex items-center gap-2 cursor-pointer">
                   <input type="checkbox" checked={selLevels().includes(level)} onChange={() => toggleLevel(level)} />
                   <LogBadge level={level} />
-                  <span class="capitalize">{level}</span>
+                  <span class="text-sm capitalize">{level}</span>
                 </label>
               )}</For>
             </div>
@@ -57,7 +58,7 @@ const FilterPopover: Component<Props> = (props) => {
 
           <div class="mb-3">
             <div class="font-medium mb-2">Monitors</div>
-            <div class="max-h-40 overflow-auto border rounded p-2">
+            <div class="max-h-40 overflow-auto border border-gray-300 rounded p-2">
               <For each={props.availableMonitors}>{m => (
                 <label class="flex items-center gap-2">
                   <input type="checkbox" checked={selMonitors().includes(m)} onChange={() => toggleMonitor(m)} />

--- a/frontend/src/components/logs-viewer/FilterPopover.tsx
+++ b/frontend/src/components/logs-viewer/FilterPopover.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, type Component } from 'solid-js';
-import LogBadge from './LogBadge';
 import Filter from 'lucide-solid/icons/filter';
+
+import LogBadge from './LogBadge';
 
 type Props = {
   levels: string[];

--- a/frontend/src/components/logs-viewer/FilterPopover.tsx
+++ b/frontend/src/components/logs-viewer/FilterPopover.tsx
@@ -1,7 +1,8 @@
 import { createSignal, For, type Component } from 'solid-js';
 import Filter from 'lucide-solid/icons/filter';
 
-import LogBadge from './LogBadge';
+import LogBadge from './LevelBadge';
+import SourceBadge from './SourceBadge';
 
 type Props = {
   levels: string[];
@@ -61,9 +62,9 @@ const FilterPopover: Component<Props> = (props) => {
             <div class="font-medium mb-2">Monitors</div>
             <div class="max-h-40 overflow-auto border border-gray-300 rounded p-2">
               <For each={props.availableMonitors}>{m => (
-                <label class="flex items-center gap-2">
+                <label class="inline-flex items-center gap-2 ml-2 mb-2 cursor-pointer">
                   <input type="checkbox" checked={selMonitors().includes(m)} onChange={() => toggleMonitor(m)} />
-                  <span class="text-sm">{m}</span>
+                  <span class="text-sm"><SourceBadge source={m} /></span>
                 </label>
               )}</For>
             </div>

--- a/frontend/src/components/logs-viewer/FilterPopover.tsx
+++ b/frontend/src/components/logs-viewer/FilterPopover.tsx
@@ -1,0 +1,80 @@
+import { createSignal, For, type Component } from 'solid-js';
+import LogBadge from './LogBadge';
+import Filter from 'lucide-solid/icons/filter';
+
+type Props = {
+  levels: string[];
+  monitors: string[];
+  availableMonitors: string[];
+  onChange: (levels: string[], monitors: string[]) => void;
+};
+
+const ALL_LEVELS = ['error', 'warning', 'info', 'debug'];
+
+const FilterPopover: Component<Props> = (props) => {
+  const [open, setOpen] = createSignal(false);
+  const [selLevels, setSelLevels] = createSignal<string[]>(props.levels ?? []);
+  const [selMonitors, setSelMonitors] = createSignal<string[]>(props.monitors ?? []);
+
+  function toggleLevel(l: string) {
+    setSelLevels((prev) => (prev.includes(l) ? prev.filter(x => x !== l) : [...prev, l]));
+  }
+
+  function toggleMonitor(m: string) {
+    setSelMonitors((prev) => (prev.includes(m) ? prev.filter(x => x !== m) : [...prev, m]));
+  }
+
+  function apply() {
+    props.onChange(selLevels(), selMonitors());
+    setOpen(false);
+  }
+
+  function reset() {
+    setSelLevels([]);
+    setSelMonitors([]);
+  }
+
+  return (
+    <div class="relative">
+      <button class="btn btn-square btn-ghost" onClick={() => setOpen(v => !v)} aria-expanded={open()} title="Filters">
+        <Filter class="w-4 h-4" />
+      </button>
+
+      {open() && (
+        <div class="absolute z-20 mt-2 p-4 bg-base-100 border rounded shadow w-72">
+          <div class="mb-3">
+            <div class="font-medium mb-2">Levels</div>
+            <div class="flex gap-2 flex-wrap">
+              <For each={ALL_LEVELS}>{level => (
+                <label class="inline-flex items-center gap-2 cursor-pointer">
+                  <input type="checkbox" checked={selLevels().includes(level)} onChange={() => toggleLevel(level)} />
+                  <LogBadge level={level} />
+                  <span class="capitalize">{level}</span>
+                </label>
+              )}</For>
+            </div>
+          </div>
+
+          <div class="mb-3">
+            <div class="font-medium mb-2">Monitors</div>
+            <div class="max-h-40 overflow-auto border rounded p-2">
+              <For each={props.availableMonitors}>{m => (
+                <label class="flex items-center gap-2">
+                  <input type="checkbox" checked={selMonitors().includes(m)} onChange={() => toggleMonitor(m)} />
+                  <span class="text-sm">{m}</span>
+                </label>
+              )}</For>
+            </div>
+          </div>
+
+          <div class="flex justify-end gap-2">
+            <button class="btn btn-sm" onClick={reset}>Reset</button>
+            <button class="btn btn-sm btn-primary" onClick={apply}>Apply</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FilterPopover;

--- a/frontend/src/components/logs-viewer/FilterPopover.tsx
+++ b/frontend/src/components/logs-viewer/FilterPopover.tsx
@@ -7,8 +7,9 @@ import SourceBadge from './SourceBadge';
 type Props = {
   levels: string[];
   monitors: string[];
+  availableSources: string[];
   availableMonitors: string[];
-  onChange: (levels: string[], monitors: string[]) => void;
+  onChange: (levels: string[], sources: string[], monitors: string[]) => void;
 };
 
 const ALL_LEVELS = ['error', 'warning', 'info', 'debug'];
@@ -17,10 +18,15 @@ const DEFAULT_LEVELS = ['error', 'warning', 'info'];
 const FilterPopover: Component<Props> = (props) => {
   const [open, setOpen] = createSignal(false);
   const [selLevels, setSelLevels] = createSignal<string[]>(props.levels ?? DEFAULT_LEVELS);
+  const [selSources, setSelSources] = createSignal<string[]>([]);
   const [selMonitors, setSelMonitors] = createSignal<string[]>(props.monitors ?? []);
 
   function toggleLevel(l: string) {
     setSelLevels((prev) => (prev.includes(l) ? prev.filter(x => x !== l) : [...prev, l]));
+  }
+
+  function toggleSource(s: string) {
+    setSelSources((prev) => (prev.includes(s) ? prev.filter(x => x !== s) : [...prev, s]));
   }
 
   function toggleMonitor(m: string) {
@@ -28,12 +34,13 @@ const FilterPopover: Component<Props> = (props) => {
   }
 
   function apply() {
-    props.onChange(selLevels(), selMonitors());
+    props.onChange(selLevels(), selSources(), selMonitors());
     setOpen(false);
   }
 
   function reset() {
     setSelLevels(DEFAULT_LEVELS);
+    setSelSources([]);
     setSelMonitors([]);
   }
 
@@ -53,6 +60,18 @@ const FilterPopover: Component<Props> = (props) => {
                   <input type="checkbox" checked={selLevels().includes(level)} onChange={() => toggleLevel(level)} />
                   <LogBadge level={level} />
                   <span class="text-sm capitalize">{level}</span>
+                </label>
+              )}</For>
+            </div>
+          </div>
+
+          <div class="mb-3">
+            <div class="font-medium mb-2">Sources</div>
+            <div class="max-h-40 overflow-auto border border-gray-300 rounded p-2">
+              <For each={props.availableSources}>{s => (
+                <label class="inline-flex items-center gap-2 ml-2 mb-2 cursor-pointer">
+                  <input type="checkbox" checked={selSources().includes(s)} onChange={() => toggleSource(s)} />
+                  <span class="text-sm"><SourceBadge source={s} /></span>
                 </label>
               )}</For>
             </div>

--- a/frontend/src/components/logs-viewer/LevelBadge.tsx
+++ b/frontend/src/components/logs-viewer/LevelBadge.tsx
@@ -7,7 +7,7 @@ const LEVELS: Record<string, { class: string; label: string; title: string }> = 
   debug: { class: 'badge-success', label: 'D', title: 'debug' },
 };
 
-const LogBadge: Component<{ level?: string }> = (props) => {
+const LevelBadge: Component<{ level?: string }> = (props) => {
   const lvl = (props.level ?? '').toLowerCase();
   const cfg = LEVELS[lvl] ?? { class: 'bg-gray-400 text-white', label: lvl ? lvl[0].toUpperCase() : '?', title: lvl || 'unknown' };
 
@@ -21,4 +21,4 @@ const LogBadge: Component<{ level?: string }> = (props) => {
   );
 };
 
-export default LogBadge;
+export default LevelBadge;

--- a/frontend/src/components/logs-viewer/LogBadge.tsx
+++ b/frontend/src/components/logs-viewer/LogBadge.tsx
@@ -1,0 +1,24 @@
+import { type Component } from 'solid-js';
+
+const LEVELS: Record<string, { class: string; label: string; title: string }> = {
+  error: { class: 'badge-error', label: 'E', title: 'error' },
+  warning: { class: 'badge-warning', label: 'W', title: 'warning' },
+  info: { class: 'badge-info', label: 'I', title: 'info' },
+  debug: { class: 'badge-success', label: 'D', title: 'debug' },
+};
+
+const LogBadge: Component<{ level?: string }> = (props) => {
+  const lvl = (props.level ?? '').toLowerCase();
+  const cfg = LEVELS[lvl] ?? { class: 'bg-gray-400 text-white', label: lvl ? lvl[0].toUpperCase() : '?', title: lvl || 'unknown' };
+
+  return (
+    <span
+      class={`badge badge-soft ${cfg.class} text-xs font-mono px-2 py-1`}
+      title={cfg.title}
+    >
+      {cfg.label}
+    </span>
+  );
+};
+
+export default LogBadge;

--- a/frontend/src/components/logs-viewer/PauseResumeButton.tsx
+++ b/frontend/src/components/logs-viewer/PauseResumeButton.tsx
@@ -1,0 +1,13 @@
+import { type Component } from 'solid-js';
+import Play from 'lucide-solid/icons/play';
+import Pause from 'lucide-solid/icons/pause';
+
+const PauseResumeButton: Component<{ paused: boolean; onToggle: () => void }> = (props) => {
+  return (
+    <button class="btn btn-square btn-ghost" title={props.paused ? 'Resume' : 'Pause'} onClick={props.onToggle}>
+      {props.paused ? <Play class="w-4 h-4" /> : <Pause class="w-4 h-4" />}
+    </button>
+  );
+};
+
+export default PauseResumeButton;

--- a/frontend/src/components/logs-viewer/SolidTable.tsx
+++ b/frontend/src/components/logs-viewer/SolidTable.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For } from 'solid-js';
+import { createEffect, createSignal, For } from 'solid-js';
 import {
   createSolidTable,
   flexRender,
@@ -23,6 +23,8 @@ interface SolidTableProps<T> {
 
 export function SolidTable<T>(props: SolidTableProps<T>) {
   const [columnFilters, setColumnFilters] = createSignal<ColumnFiltersState>([])
+  const [selectedLevels, setSelectedLevels] = createSignal<string[]>(props.filters?.levels ?? []);
+  const [selectedMonitors, setSelectedMonitors] = createSignal<string[]>(props.filters?.monitors ?? []);
 
   const table = createSolidTable({
     get data() { return props.data; },
@@ -44,8 +46,23 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
     onColumnFiltersChange: setColumnFilters,
   });
 
+  createEffect(() => {
+    const column = table.getColumn("level");
+    console.log(selectedLevels());
+    if (column) {
+      column.setFilterValue(selectedLevels());
+    }
+  });
+
+  createEffect(() => {
+    const column = table.getColumn("monitorID");
+    if (column) {
+      column.setFilterValue(selectedMonitors());
+    }
+  });
+
   return (
-    <div class="overflow-hidden border-gray-600 w-full">
+    <div class="overflow-hidden border-gray-600 w-full h-full">
       <div class='flex items-center p-4 gap-2'>
         <input
           placeholder="Filter messages..."
@@ -57,7 +74,11 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
           levels={props.filters?.levels ?? []}
           monitors={props.filters?.monitors ?? []}
           availableMonitors={props.availableMonitors ?? []}
-          onChange={(levels, monitors) => props.onFiltersChange?.(levels, monitors)}
+          onChange={(levels, monitors) => {
+            setSelectedLevels(levels);
+            setSelectedMonitors(monitors);
+            props.onFiltersChange?.(levels, monitors);
+          }}
         />
         <PauseResumeButton paused={!!props.paused} onToggle={() => props.onTogglePause?.()} />
       </div>

--- a/frontend/src/components/logs-viewer/SolidTable.tsx
+++ b/frontend/src/components/logs-viewer/SolidTable.tsx
@@ -16,7 +16,6 @@ interface SolidTableProps<T> {
   columns: ColumnDef<T, any>[];
   availableMonitors?: string[];
   filters?: { levels?: string[]; monitors?: string[] };
-  onFiltersChange?: (levels: string[], monitors: string[]) => void;
   paused?: boolean;
   onTogglePause?: () => void;
 }
@@ -76,7 +75,6 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
           onChange={(levels, monitors) => {
             setSelectedLevels(levels);
             setSelectedMonitors(monitors);
-            props.onFiltersChange?.(levels, monitors);
           }}
         />
         <PauseResumeButton paused={!!props.paused} onToggle={() => props.onTogglePause?.()} />

--- a/frontend/src/components/logs-viewer/SolidTable.tsx
+++ b/frontend/src/components/logs-viewer/SolidTable.tsx
@@ -14,8 +14,9 @@ import PauseResumeButton from './PauseResumeButton';
 interface SolidTableProps<T> {
   data: T[];
   columns: ColumnDef<T, any>[];
+  availableSources?: string[];
   availableMonitors?: string[];
-  filters?: { levels?: string[]; monitors?: string[] };
+  filters?: { levels?: string[]; sources?: string[], monitors?: string[] };
   paused?: boolean;
   onTogglePause?: () => void;
 }
@@ -23,6 +24,7 @@ interface SolidTableProps<T> {
 export function SolidTable<T>(props: SolidTableProps<T>) {
   const [columnFilters, setColumnFilters] = createSignal<ColumnFiltersState>([])
   const [selectedLevels, setSelectedLevels] = createSignal<string[]>(props.filters?.levels ?? []);
+  const [selectedSources, setSelectedSources] = createSignal<string[]>(props.filters?.sources ?? []);
   const [selectedMonitors, setSelectedMonitors] = createSignal<string[]>(props.filters?.monitors ?? []);
 
   const table = createSolidTable({
@@ -53,6 +55,13 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
   });
 
   createEffect(() => {
+    const column = table.getColumn("source");
+    if (column) {
+      column.setFilterValue(selectedSources());
+    }
+  });
+
+  createEffect(() => {
     const column = table.getColumn("monitorID");
     if (column) {
       column.setFilterValue(selectedMonitors());
@@ -71,9 +80,11 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
         <FilterPopover
           levels={props.filters?.levels ?? []}
           monitors={props.filters?.monitors ?? []}
+          availableSources={props.availableSources ?? []}
           availableMonitors={props.availableMonitors ?? []}
-          onChange={(levels, monitors) => {
+          onChange={(levels, sources, monitors) => {
             setSelectedLevels(levels);
+            setSelectedSources(sources);
             setSelectedMonitors(monitors);
           }}
         />

--- a/frontend/src/components/logs-viewer/SolidTable.tsx
+++ b/frontend/src/components/logs-viewer/SolidTable.tsx
@@ -7,7 +7,6 @@ import {
   getSortedRowModel,
   ColumnDef,
   ColumnFiltersState,
-  VisibilityState,
 } from '@tanstack/solid-table';
 import FilterPopover from './FilterPopover';
 import PauseResumeButton from './PauseResumeButton';
@@ -24,10 +23,6 @@ interface SolidTableProps<T> {
 
 export function SolidTable<T>(props: SolidTableProps<T>) {
   const [columnFilters, setColumnFilters] = createSignal<ColumnFiltersState>([])
-  const [columnVisibility, setColumnVisibility] = createSignal<VisibilityState>({
-    monitorID: false,
-    source: false,
-  })
 
   const table = createSolidTable({
     get data() { return props.data; },
@@ -42,13 +37,11 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
         ]
       },
       get columnFilters() { return columnFilters(); },
-      get columnVisibility() { return columnVisibility(); },
     },
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     onColumnFiltersChange: setColumnFilters,
-    onColumnVisibilityChange: setColumnVisibility,
   });
 
   return (
@@ -75,7 +68,7 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
               <tr>
                 <For each={headerGroup.headers}>
                   {header => (
-                    <th colSpan={header.colSpan}>
+                    <th colSpan={header.colSpan} >
                       {flexRender(
                         header.column.columnDef.header,
                         header.getContext(),

--- a/frontend/src/components/logs-viewer/SolidTable.tsx
+++ b/frontend/src/components/logs-viewer/SolidTable.tsx
@@ -48,7 +48,6 @@ export function SolidTable<T>(props: SolidTableProps<T>) {
 
   createEffect(() => {
     const column = table.getColumn("level");
-    console.log(selectedLevels());
     if (column) {
       column.setFilterValue(selectedLevels());
     }

--- a/frontend/src/components/logs-viewer/SourceBadge.tsx
+++ b/frontend/src/components/logs-viewer/SourceBadge.tsx
@@ -1,0 +1,16 @@
+import { type Component } from 'solid-js';
+
+const SourceBadge: Component<{ source: string }> = (props) => {
+  const src = (props.source ?? '').toLowerCase();
+
+  return (
+    <span
+      class={`badge badge-soft badge-info text-xs font-mono px-2 py-1`}
+      title={src}
+    >
+      {src}
+    </span>
+  );
+};
+
+export default SourceBadge;

--- a/frontend/src/components/logs-viewer/columns.tsx
+++ b/frontend/src/components/logs-viewer/columns.tsx
@@ -13,7 +13,6 @@ export const columns: ColumnDef<LogEntry, any>[] = [
   {
     accessorKey: 'time',
     header: 'Time',
-    size: 80,
     cell: ({ row }) => {
       const microseconds = parseFloat(row.getValue('time'));
       const milliseconds = Math.floor(microseconds / 1000);
@@ -26,7 +25,6 @@ export const columns: ColumnDef<LogEntry, any>[] = [
   {
     accessorKey: 'level',
     header: 'Level',
-    size: 80,
     cell: ({ row }) => {
       const lv = row.getValue('level') as string;
       return <LogBadge level={lv} />;
@@ -35,7 +33,6 @@ export const columns: ColumnDef<LogEntry, any>[] = [
   {
     accessorKey: 'message',
     header: 'Message',
-    size: 0,
     cell: ({ row }) => {
       const msg = row.getValue('message') as string;
       return <div>{msg}</div>;
@@ -48,7 +45,6 @@ export const columns: ColumnDef<LogEntry, any>[] = [
       const source = row.getValue('source') as string;
       return <span class='hidden md:table-cell'>{source}</span>;
     },
-    size: 120,
   },
   {
     accessorKey: 'monitorID',
@@ -57,7 +53,6 @@ export const columns: ColumnDef<LogEntry, any>[] = [
       const monitorID = row.getValue('monitorID') as string;
       return <span class='hidden md:table-cell'>{monitorID}</span>;
     },
-    size: 120,
   },
 ];
 

--- a/frontend/src/components/logs-viewer/columns.tsx
+++ b/frontend/src/components/logs-viewer/columns.tsx
@@ -54,6 +54,7 @@ export const columns: ColumnDef<LogEntry, any>[] = [
     header: () => <span class='hidden md:table-cell'>Monitor</span>,
     cell: ({ row }) => {
       const monitorID = row.getValue('monitorID') as string;
+      if (!monitorID || monitorID?.length === 0) return <span class='hidden md:table-cell'>-</span>;
       return <span class='hidden md:table-cell'><SourceBadge source={monitorID} /></span>;
     },
     filterFn: 'arrIncludesSome',
@@ -61,7 +62,7 @@ export const columns: ColumnDef<LogEntry, any>[] = [
 ];
 
 export const DEFAULT_LOGS: LogEntry[] = [
-  { time: 1672531199000000, level: 'info', source: 'system', monitorID: 'mon1', message: 'System started successfully.' },
+  { time: 1672531199000000, level: 'info', source: 'system', monitorID: undefined, message: 'System started successfully.' },
   { time: 1672531299000000, level: 'warning', source: 'auth', monitorID: 'mon2', message: 'Multiple failed login attempts detected.' },
   { time: 1672531399000000, level: 'error', source: 'database', monitorID: 'mon3', message: 'Database connection lost.' },
   { time: 1672531499000000, level: 'debug', source: 'api', monitorID: 'mon4', message: 'API request received with payload size of 512 bytes.' },

--- a/frontend/src/components/logs-viewer/columns.tsx
+++ b/frontend/src/components/logs-viewer/columns.tsx
@@ -43,14 +43,21 @@ export const columns: ColumnDef<LogEntry, any>[] = [
   },
   {
     accessorKey: 'source',
-    header: 'Source',
+    header: () => <span class='hidden md:table-cell'>Source</span>,
+    cell: ({ row }) => {
+      const source = row.getValue('source') as string;
+      return <span class='hidden md:table-cell'>{source}</span>;
+    },
     size: 120,
   },
   {
     accessorKey: 'monitorID',
-    header: 'Monitor',
+    header: () => <span class='hidden md:table-cell'>Monitor</span>,
+    cell: ({ row }) => {
+      const monitorID = row.getValue('monitorID') as string;
+      return <span class='hidden md:table-cell'>{monitorID}</span>;
+    },
     size: 120,
-    enableHiding: true,
   },
 ];
 

--- a/frontend/src/components/logs-viewer/columns.tsx
+++ b/frontend/src/components/logs-viewer/columns.tsx
@@ -1,4 +1,5 @@
 import { ColumnDef } from '@tanstack/solid-table';
+import LogBadge from './LogBadge';
 
 export type LogEntry = {
   level: string;
@@ -10,35 +11,46 @@ export type LogEntry = {
 
 export const columns: ColumnDef<LogEntry, any>[] = [
   {
-    accessorKey: "time",
-    header: "Time",
-    size: 180,
+    accessorKey: 'time',
+    header: 'Time',
+    size: 80,
     cell: ({ row }) => {
-      const microseconds = parseFloat(row.getValue("time"));
+      const microseconds = parseFloat(row.getValue('time'));
       const milliseconds = Math.floor(microseconds / 1000);
-      const formatted = new Date(milliseconds).toLocaleString();
-      return formatted;
+      const d = new Date(milliseconds);
+      const short = d.toLocaleTimeString();
+      const full = d.toISOString();
+      return <span title={full}>{short}</span>;
     },
   },
   {
-    accessorKey: "level",
-    header: "Level",
-    size: 100,
+    accessorKey: 'level',
+    header: 'Level',
+    size: 80,
+    cell: ({ row }) => {
+      const lv = row.getValue('level') as string;
+      return <LogBadge level={lv} />;
+    },
   },
   {
-    accessorKey: "source",
-    header: "Source",
-    size: 150,
-  },
-  {
-    accessorKey: "monitorID",
-    header: "Monitor ID",
-    size: 150,
-  },
-  {
-    accessorKey: "message",
-    header: "Message",
+    accessorKey: 'message',
+    header: 'Message',
     size: 0,
+    cell: ({ row }) => {
+      const msg = row.getValue('message') as string;
+      return <div>{msg}</div>;
+    },
+  },
+  {
+    accessorKey: 'source',
+    header: 'Source',
+    size: 120,
+  },
+  {
+    accessorKey: 'monitorID',
+    header: 'Monitor',
+    size: 120,
+    enableHiding: true,
   },
 ];
 

--- a/frontend/src/components/logs-viewer/columns.tsx
+++ b/frontend/src/components/logs-viewer/columns.tsx
@@ -1,5 +1,6 @@
 import { ColumnDef } from '@tanstack/solid-table';
-import LogBadge from './LogBadge';
+import LogBadge from './LevelBadge';
+import SourceBadge from './SourceBadge';
 
 export type LogEntry = {
   level: string;
@@ -44,7 +45,7 @@ export const columns: ColumnDef<LogEntry, any>[] = [
     header: () => <span class='hidden md:table-cell'>Source</span>,
     cell: ({ row }) => {
       const source = row.getValue('source') as string;
-      return <span class='hidden md:table-cell'>{source}</span>;
+      return <span class='hidden md:table-cell'><SourceBadge source={source} /></span>;
     },
   },
   {
@@ -52,7 +53,7 @@ export const columns: ColumnDef<LogEntry, any>[] = [
     header: () => <span class='hidden md:table-cell'>Monitor</span>,
     cell: ({ row }) => {
       const monitorID = row.getValue('monitorID') as string;
-      return <span class='hidden md:table-cell'>{monitorID}</span>;
+      return <span class='hidden md:table-cell'><SourceBadge source={monitorID} /></span>;
     },
     filterFn: 'arrIncludesSome',
   },

--- a/frontend/src/components/logs-viewer/columns.tsx
+++ b/frontend/src/components/logs-viewer/columns.tsx
@@ -47,6 +47,7 @@ export const columns: ColumnDef<LogEntry, any>[] = [
       const source = row.getValue('source') as string;
       return <span class='hidden md:table-cell'><SourceBadge source={source} /></span>;
     },
+    filterFn: 'arrIncludesSome',
   },
   {
     accessorKey: 'monitorID',

--- a/frontend/src/components/logs-viewer/columns.tsx
+++ b/frontend/src/components/logs-viewer/columns.tsx
@@ -29,6 +29,7 @@ export const columns: ColumnDef<LogEntry, any>[] = [
       const lv = row.getValue('level') as string;
       return <LogBadge level={lv} />;
     },
+    filterFn: 'arrIncludesSome',
   },
   {
     accessorKey: 'message',
@@ -53,6 +54,7 @@ export const columns: ColumnDef<LogEntry, any>[] = [
       const monitorID = row.getValue('monitorID') as string;
       return <span class='hidden md:table-cell'>{monitorID}</span>;
     },
+    filterFn: 'arrIncludesSome',
   },
 ];
 

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -62,7 +62,7 @@ async function slowPoll(
 
 const Logs: Component = () => {
   const [logs, setLogs] = createSignal<LogEntry[]>([]);
-  const defaultFilters = { levels: DEFAULT_LEVELS, monitors: [] };
+  const defaultFilters = { levels: DEFAULT_LEVELS, monitors: [], sources: [] };
   const [paused, setPaused] = createSignal(false);
   let lastTimeRef: number | undefined = undefined;
   let abortController: AbortController | null = null;

--- a/frontend/src/pages/Logs.tsx
+++ b/frontend/src/pages/Logs.tsx
@@ -120,6 +120,7 @@ const Logs: Component = () => {
         <SolidTable
           data={logs()}
           columns={columns}
+          availableSources={[...new Set(logs().map(l => l.source).filter(Boolean))] as string[]}
           availableMonitors={[...new Set(logs().map(l => l.monitorID).filter(Boolean))] as string[]}
           filters={defaultFilters}
           paused={paused()}


### PR DESCRIPTION
This pull request introduces a significant update to the logs viewer frontend, focusing on improved filtering, UI component upgrades, and enhanced log presentation. The main changes include replacing the UI library, adding interactive filter and pause/resume controls, and refactoring the logs table for better usability and clarity.

**UI Library Update:**
* Switched UI components from `shadcn/ui` to `daisyUI` for styling consistency and easier integration.

**Logs Viewer Feature Enhancements:**
* Added a new `FilterPopover` component, allowing users to filter logs by level, source, and monitor interactively.
* Introduced a `PauseResumeButton` component to pause and resume live log updates directly from the UI.
* Refactored the `SolidTable` component to support external filters and pause/resume functionality, integrating the new filter and control components. [[1]](diffhunk://#diff-85be747de371f7b1fdf2af5bc7368cda25c6ec9ed524402ad089891925ee7b05R11-R28) [[2]](diffhunk://#diff-85be747de371f7b1fdf2af5bc7368cda25c6ec9ed524402ad089891925ee7b05L32-R93)

**Log Presentation Improvements:**
* Updated log column definitions to use custom badges (`LevelBadge`, `SourceBadge`) for clearer visual distinction of levels and sources, and improved time formatting for readability. [[1]](diffhunk://#diff-f7a89c7ed26d98bd89e365ea84bd8af1a5298a9094ec7622c9c11eb6c9b8de4eR2-R3) [[2]](diffhunk://#diff-f7a89c7ed26d98bd89e365ea84bd8af1a5298a9094ec7622c9c11eb6c9b8de4eL13-R65) [[3]](diffhunk://#diff-f8c4b8fbbdc951d557cbf5e7652ff39aedcbbdb76f7b50234b43908a2a039f4eR1-R24) [[4]](diffhunk://#diff-e62e445d5cad1f21b700316c1456be16633c6357b3a4df1ddab490ec7c6bb48eR1-R16)
* Enhanced log polling logic to support pausing, and initialized filters for a more controlled log stream. [[1]](diffhunk://#diff-66b0539b7f2d7baa233c58f5758e74a70acca2231788a1114a5b2425430bfe42R65-R74) [[2]](diffhunk://#diff-66b0539b7f2d7baa233c58f5758e74a70acca2231788a1114a5b2425430bfe42R89-R95) [[3]](diffhunk://#diff-66b0539b7f2d7baa233c58f5758e74a70acca2231788a1114a5b2425430bfe42L113-R128)