### PR TITLE
Convert EnvData into data context to be shared between pages.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, type Component } from 'solid-js';
-
 import { Router, Route, Navigate } from '@solidjs/router';
+
+import { EnvDataProvider } from '@/contexts/env-data';
 
 const LiveView = lazy(() => import('@/pages/LiveView'));
 const Recordings = lazy(() => import('@/pages/Recordings'));
@@ -9,13 +10,15 @@ const Logs = lazy(() => import('@/pages/Logs'));
 
 const App: Component = () => {
   return (
-    <Router base='/frontend'>
-      <Route path="/" component={() => <Navigate href="/live" />} />
-      <Route path="/live" component={LiveView} />
-      <Route path="/recordings" component={Recordings} />
-      <Route path="/settings" component={Settings} />
-      <Route path="/logs" component={Logs} />
-    </Router>
+    <EnvDataProvider>
+      <Router base='/frontend'>
+        <Route path="/" component={() => <Navigate href="/live" />} />
+        <Route path="/live" component={LiveView} />
+        <Route path="/recordings" component={Recordings} />
+        <Route path="/settings" component={Settings} />
+        <Route path="/logs" component={Logs} />
+      </Router>
+    </EnvDataProvider>
   );
 };
 

--- a/frontend/src/contexts/env-data.tsx
+++ b/frontend/src/contexts/env-data.tsx
@@ -1,0 +1,38 @@
+import { createContext, createResource, JSX, Resource, useContext, onCleanup } from 'solid-js';
+
+export type EnvData = {
+  flags?: Record<string, unknown>;
+  monitorConfig?: Record<string, unknown>;
+  monitorsInfo?: Record<string, unknown>;
+  monitor_info?: Record<string, unknown>;
+  monitorGroup?: Record<string, unknown>;
+  logSources?: Array<unknown>;
+  csrfToken?: string;
+};
+
+// Create a context and provide an initial value.
+const DataContext = createContext<Resource<EnvData>>({} as Resource<EnvData>);
+
+export const EnvDataProvider = (props: { children: JSX.Element }) => {
+  const abortController = new AbortController();
+  onCleanup(() => abortController.abort());
+
+  // createResource is called once when the provider is created.
+  const [envData] = createResource<EnvData>(async () => {
+    const res = await fetch("/frontend/api/env", {
+      signal: abortController.signal
+    });
+    if (!res.ok) {
+      throw new Error(`API call failed with status: ${res.status}`);
+    }
+    return res.json() as Promise<EnvData>;
+  });
+
+  return (
+    <DataContext.Provider value={envData}>
+      {props.children}
+    </DataContext.Provider>
+  );
+};
+
+export const useEnvData = () => useContext(DataContext);

--- a/frontend/src/contexts/env-data.tsx
+++ b/frontend/src/contexts/env-data.tsx
@@ -14,11 +14,9 @@ export type EnvData = {
 const DataContext = createContext<Resource<EnvData>>({} as Resource<EnvData>);
 
 export const EnvDataProvider = (props: { children: JSX.Element }) => {
-  const abortController = new AbortController();
-  onCleanup(() => abortController.abort());
-
-  // createResource is called once when the provider is created.
   const [envData] = createResource<EnvData>(async () => {
+    const abortController = new AbortController();
+    onCleanup(() => abortController.abort());
     const res = await fetch("/frontend/api/env", {
       signal: abortController.signal
     });

--- a/frontend/src/pages/LiveView.tsx
+++ b/frontend/src/pages/LiveView.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createResource, createSignal, onCleanup, type Component } from 'solid-js';
+import { createEffect, createSignal, onCleanup, type Component } from 'solid-js';
 import PanelLeft from 'lucide-solid/icons/panel-left';
 import Plus from 'lucide-solid/icons/plus';
 import Minus from 'lucide-solid/icons/minus';
@@ -10,16 +10,7 @@ import { setGlobals } from "@/components/viewer/libs/common";
 
 import AppSidebar from '@/components/AppSidebar';
 
-
-type EnvData = {
-  flags?: Record<string, unknown>;
-  monitorConfig?: Record<string, unknown>;
-  monitorsInfo?: Record<string, unknown>;
-  monitor_info?: Record<string, unknown>;
-  monitorGroup?: Record<string, unknown>;
-  logSources?: Array<unknown>;
-  csrfToken?: string;
-};
+import { useEnvData, EnvData } from '@/contexts/env-data';
 
 function applyEnvGlobals(envData?: EnvData) {
   if (!envData) return;
@@ -48,13 +39,7 @@ const LiveView: Component = () => {
   const MAX_GRID = 4;
   const [gridSize, setGridSize] = createSignal<number>(3);
 
-  const [envData] = createResource<EnvData>(async () => {
-    const res = await fetch("/frontend/api/env");
-    if (!res.ok) {
-      throw new Error(`API call failed with status: ${res.status}`);
-    }
-    return res.json() as Promise<EnvData>;
-  });
+  const envData = useEnvData();
 
   createEffect(() => {
     if (envData.loading) {

--- a/frontend/src/pages/Recordings.tsx
+++ b/frontend/src/pages/Recordings.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createResource, createSignal, onCleanup, type Component } from 'solid-js';
+import { createEffect, createSignal, onCleanup, type Component } from 'solid-js';
 import PanelLeft from 'lucide-solid/icons/panel-left';
 import Plus from 'lucide-solid/icons/plus';
 import Minus from 'lucide-solid/icons/minus';
@@ -10,16 +10,7 @@ import { setGlobals, newMonitorNameByID } from "@/components/viewer/libs/common"
 
 import AppSidebar from '@/components/AppSidebar';
 
-
-type EnvData = {
-  flags?: Record<string, unknown>;
-  monitorConfig?: Record<string, unknown>;
-  monitorsInfo?: Record<string, unknown>;
-  monitor_info?: Record<string, unknown>;
-  monitorGroup?: Record<string, unknown>;
-  logSources?: Array<unknown>;
-  csrfToken?: string;
-};
+import { useEnvData, EnvData } from '@/contexts/env-data';
 
 function applyEnvGlobals(envData?: EnvData) {
   if (!envData) return;
@@ -48,13 +39,7 @@ const Recordings: Component = () => {
   const MAX_GRID = 4;
   const [gridSize, setGridSize] = createSignal<number>(3);
 
-  const [envData] = createResource<EnvData>(async () => {
-    const res = await fetch("/frontend/api/env");
-    if (!res.ok) {
-      throw new Error(`API call failed with status: ${res.status}`);
-    }
-    return res.json() as Promise<EnvData>;
-  });
+  const envData = useEnvData();
 
   createEffect(() => {
     if (envData.loading) {


### PR DESCRIPTION
This pull request introduces a centralized context provider for environment data, refactors related components to use this new provider, and removes duplicate environment data fetching logic from individual pages. The main goal is to improve code maintainability and enable easier sharing of environment data across the application.

**Centralized Environment Data Management:**

* Added a new `EnvDataProvider` and `useEnvData` hook in `frontend/src/contexts/env-data.tsx` to fetch and provide environment data via React context. This allows all child components to access environment data without duplicating fetch logic.
* Updated the root `App` component in `frontend/src/App.tsx` to wrap the application in `EnvDataProvider`, ensuring environment data is available throughout the app.

**Component Refactoring:**

* Refactored `LiveView` and `Recordings` pages to use `useEnvData` instead of fetching environment data with `createResource`, and removed their local `EnvData` type definitions. This simplifies the code and ensures consistent access to environment data. [[1]](diffhunk://#diff-b660feab9e7ac701315f51f4623009b31e1d9414fcadba27fa4dfbd67cd3dfdfL13-R13) [[2]](diffhunk://#diff-b660feab9e7ac701315f51f4623009b31e1d9414fcadba27fa4dfbd67cd3dfdfL51-R42) [[3]](diffhunk://#diff-5ada0bac0ab1ae09019a2cc643944d1a970c9e17d895e6cd6c22614005fe2d59L13-R13) [[4]](diffhunk://#diff-5ada0bac0ab1ae09019a2cc643944d1a970c9e17d895e6cd6c22614005fe2d59L51-R42)

**Code Cleanup:**

* Removed unused imports of `createResource` from both `LiveView.tsx` and `Recordings.tsx`, as environment data is now provided via context. [[1]](diffhunk://#diff-b660feab9e7ac701315f51f4623009b31e1d9414fcadba27fa4dfbd67cd3dfdfL1-R1) [[2]](diffhunk://#diff-5ada0bac0ab1ae09019a2cc643944d1a970c9e17d895e6cd6c22614005fe2d59L1-R1)